### PR TITLE
Fix sauce connect not stopping after jobs are over - ECO-1054

### DIFF
--- a/src/main/java/com/saucelabs/bamboo/sod/action/BuildConfigurator.java
+++ b/src/main/java/com/saucelabs/bamboo/sod/action/BuildConfigurator.java
@@ -16,6 +16,7 @@ import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.util.ValueStack;
 import com.saucelabs.bamboo.sod.config.SODKeys;
 import com.saucelabs.bamboo.sod.config.SODMappedBuildConfiguration;
+import com.saucelabs.bamboo.sod.singletons.SauceConnectFourManagerSingleton;
 import com.saucelabs.bamboo.sod.util.BambooSauceFactory;
 import com.saucelabs.bamboo.sod.util.SauceLogInterceptor;
 import com.saucelabs.ci.Browser;
@@ -128,7 +129,7 @@ public class BuildConfigurator extends BaseConfigurableBuildPlugin implements Cu
                 buildLogger.addBuildLogEntry(x);
             }
         };
-        SauceTunnelManager sauceTunnelManager = getSauceConnectFourTunnelManager();
+        SauceTunnelManager sauceTunnelManager = SauceConnectFourManagerSingleton.getSauceConnectFourTunnelManager();
         String options = getResolvedOptions(config.getSauceConnectOptions());
         sauceTunnelManager.openConnection(
             config.getTempUsername(),
@@ -284,15 +285,6 @@ public class BuildConfigurator extends BaseConfigurableBuildPlugin implements Cu
         this.sauceAPIFactory = sauceAPIFactory;
     }
 
-
-
-    public SauceConnectFourManager getSauceConnectFourTunnelManager() {
-        if (sauceConnectFourTunnelManager == null) {
-            setSauceConnectFourTunnelManager(new SauceConnectFourManager());
-        }
-        return sauceConnectFourTunnelManager;
-    }
-
     public BambooSauceFactory getSauceAPIFactory() {
         if (sauceAPIFactory == null) {
             setSauceAPIFactory(new BambooSauceFactory());
@@ -309,10 +301,6 @@ public class BuildConfigurator extends BaseConfigurableBuildPlugin implements Cu
 
     public void setPlanManager(PlanManager planManager) {
         this.planManager = planManager;
-    }
-
-    public void setSauceConnectFourTunnelManager(SauceConnectFourManager sauceConnectFourTunnelManager) {
-        this.sauceConnectFourTunnelManager = sauceConnectFourTunnelManager;
     }
 
     public void setCustomVariableContext(CustomVariableContext customVariableContext) {

--- a/src/main/java/com/saucelabs/bamboo/sod/action/PostBuildAction.java
+++ b/src/main/java/com/saucelabs/bamboo/sod/action/PostBuildAction.java
@@ -15,6 +15,7 @@ import com.atlassian.bamboo.variable.CustomVariableContext;
 import com.atlassian.spring.container.ContainerManager;
 import com.saucelabs.bamboo.sod.AbstractSauceBuildPlugin;
 import com.saucelabs.bamboo.sod.config.SODMappedBuildConfiguration;
+import com.saucelabs.bamboo.sod.singletons.SauceConnectFourManagerSingleton;
 import com.saucelabs.ci.JobInformation;
 import com.saucelabs.ci.sauceconnect.SauceConnectFourManager;
 import com.saucelabs.ci.sauceconnect.SauceTunnelManager;
@@ -52,7 +53,6 @@ public class PostBuildAction extends AbstractSauceBuildPlugin implements CustomB
     private static final Pattern SESSION_ID_PATTERN = Pattern.compile("SauceOnDemandSessionID=([0-9a-fA-F]+)(?:.job-name=(.*))?");
     private static final String JOB_NAME_PATTERN = "\\b({0})\\b";
 
-
     /**
      * Populated via dependency injection.
      */
@@ -63,10 +63,6 @@ public class PostBuildAction extends AbstractSauceBuildPlugin implements CustomB
      */
     private BuildLoggerManager buildLoggerManager;
 
-
-
-
-    private SauceConnectFourManager sauceConnectFourTunnelManager;
     private CustomVariableContext customVariableContext;
 
     @NotNull
@@ -84,7 +80,7 @@ public class PostBuildAction extends AbstractSauceBuildPlugin implements CustomB
             };
 
             try {
-                SauceTunnelManager sauceTunnelManager = getSauceConnectFourTunnelManager();
+                SauceTunnelManager sauceTunnelManager = SauceConnectFourManagerSingleton.getSauceConnectFourTunnelManager();
                 String options = customVariableContext.substituteString(config.getSauceConnectOptions(), buildContext, null);
                 sauceTunnelManager.closeTunnelsForPlan(
                     config.getTempUsername(),
@@ -290,17 +286,6 @@ public class PostBuildAction extends AbstractSauceBuildPlugin implements CustomB
 
     public void setBuildLoggerManager(BuildLoggerManager buildLoggerManager) {
         this.buildLoggerManager = buildLoggerManager;
-    }
-
-    public SauceConnectFourManager getSauceConnectFourTunnelManager() {
-        if (sauceConnectFourTunnelManager == null) {
-            setSauceConnectFourTunnelManager(new SauceConnectFourManager());
-        }
-        return sauceConnectFourTunnelManager;
-    }
-
-    public void setSauceConnectFourTunnelManager(SauceConnectFourManager sauceConnectFourTunnelManager) {
-        this.sauceConnectFourTunnelManager = sauceConnectFourTunnelManager;
     }
 
     public void setCustomVariableContext(CustomVariableContext customVariableContext) {

--- a/src/main/java/com/saucelabs/bamboo/sod/singletons/SauceConnectFourManagerSingleton.java
+++ b/src/main/java/com/saucelabs/bamboo/sod/singletons/SauceConnectFourManagerSingleton.java
@@ -1,0 +1,22 @@
+package com.saucelabs.bamboo.sod.singletons;
+
+import com.saucelabs.ci.sauceconnect.SauceConnectFourManager;
+
+/**
+ * Created by gavinmogan on 2016-02-24.
+ */
+public class SauceConnectFourManagerSingleton {
+
+    private static SauceConnectFourManager sauceConnectFourTunnelManager;
+
+    public static SauceConnectFourManager getSauceConnectFourTunnelManager() {
+        if (SauceConnectFourManagerSingleton.sauceConnectFourTunnelManager == null) {
+            setSauceConnectFourTunnelManager(new SauceConnectFourManager());
+        }
+        return SauceConnectFourManagerSingleton.sauceConnectFourTunnelManager;
+    }
+
+    public static void setSauceConnectFourTunnelManager(SauceConnectFourManager sauceConnectFourTunnelManager) {
+        SauceConnectFourManagerSingleton.sauceConnectFourTunnelManager = sauceConnectFourTunnelManager;
+    }
+}

--- a/src/test/java/com/saucelabs/bamboo/sod/action/BuildConfiguratorTest.java
+++ b/src/test/java/com/saucelabs/bamboo/sod/action/BuildConfiguratorTest.java
@@ -11,6 +11,7 @@ import com.atlassian.bamboo.ww2.actions.build.admin.create.BuildConfiguration;
 import com.atlassian.spring.container.ContainerManager;
 import com.saucelabs.bamboo.sod.AbstractTestHelper;
 import com.saucelabs.bamboo.sod.config.SODKeys;
+import com.saucelabs.bamboo.sod.singletons.SauceConnectFourManagerSingleton;
 import com.saucelabs.bamboo.sod.util.BambooSauceFactory;
 import com.saucelabs.ci.Browser;
 import com.saucelabs.ci.BrowserFactory;
@@ -62,7 +63,7 @@ public class BuildConfiguratorTest extends AbstractTestHelper {
                 return null;
             }
         };
-        buildConfigurator.setSauceConnectFourTunnelManager(tunnelManager);
+        SauceConnectFourManagerSingleton.setSauceConnectFourTunnelManager(tunnelManager);
 
         BuildContext buildContext = mock(BuildContext.class);
         CurrentBuildResult buildResult = mock(CurrentBuildResult.class);


### PR DESCRIPTION
Create a singleton for SauceConnectFourManager because it actually has a
global instance in a non static way to track open sauce connect instances.

Instead of spending the time of fixing ci-sauce and potentially breaking
other things, I just re-enabled the single instance.