### PR TITLE
Remove 'SauceJobs' tab on jobs that are not enabled

### DIFF
--- a/src/main/java/com/saucelabs/bamboo/sod/plan/ViewSODCondition.java
+++ b/src/main/java/com/saucelabs/bamboo/sod/plan/ViewSODCondition.java
@@ -42,7 +42,7 @@ public class ViewSODCondition implements Condition {
      */
     @Override
     public boolean shouldDisplay(Map<String, Object> context) {
-        if (!context.containsValue("buildKey")) { return true; }
+        if (!context.containsKey("buildKey")) { return true; }
         Plan plan = planManager.getPlanByKey(PlanKeys.getPlanKey(context.get("buildKey").toString()));
         if (plan == null) { return true; }
         SODMappedBuildConfiguration config = new SODMappedBuildConfiguration(

--- a/src/main/java/com/saucelabs/bamboo/sod/plan/ViewSODCondition.java
+++ b/src/main/java/com/saucelabs/bamboo/sod/plan/ViewSODCondition.java
@@ -1,7 +1,12 @@
 package com.saucelabs.bamboo.sod.plan;
 
+import com.atlassian.bamboo.plan.Plan;
+import com.atlassian.bamboo.plan.PlanKeys;
+import com.atlassian.bamboo.plan.PlanManager;
+import com.atlassian.bamboo.v2.build.BuildContext;
 import com.atlassian.plugin.PluginParseException;
 import com.atlassian.plugin.web.Condition;
+import com.saucelabs.bamboo.sod.config.SODMappedBuildConfiguration;
 
 import java.util.Map;
 
@@ -12,6 +17,16 @@ import java.util.Map;
  * @author Ross Rowe
  */
 public class ViewSODCondition implements Condition {
+    protected PlanManager planManager;
+
+    public PlanManager getPlanManager() {
+        return planManager;
+    }
+
+    public void setPlanManager(PlanManager planManager) {
+        this.planManager = planManager;
+    }
+
 
     /**
      * {@inheritDoc}
@@ -27,6 +42,13 @@ public class ViewSODCondition implements Condition {
      */
     @Override
     public boolean shouldDisplay(Map<String, Object> context) {
-        return true;
+        if (!context.containsValue("buildKey")) { return true; }
+        Plan plan = planManager.getPlanByKey(PlanKeys.getPlanKey(context.get("buildKey").toString()));
+        if (plan == null) { return true; }
+        SODMappedBuildConfiguration config = new SODMappedBuildConfiguration(
+            plan.getBuildDefinition().getCustomConfiguration()
+        );
+        if (config == null) { return true; }
+        return config.isEnabled();
     }
 }

--- a/src/main/java/com/saucelabs/bamboo/sod/plan/ViewSODCondition.java
+++ b/src/main/java/com/saucelabs/bamboo/sod/plan/ViewSODCondition.java
@@ -19,16 +19,11 @@ import java.util.Map;
  * @author Ross Rowe
  */
 public class ViewSODCondition implements Condition {
-    protected PlanManager planManager;
-
-    public PlanManager getPlanManager() {
-        return planManager;
-    }
+    private PlanManager planManager;
 
     public void setPlanManager(PlanManager planManager) {
         this.planManager = planManager;
     }
-
 
     /**
      * {@inheritDoc}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -95,7 +95,6 @@
         <label key="Sauce Jobs"/>
         <link linkId="saucePlanDetails">/build/result/viewSauceOnDemandResult.action?buildKey=${buildKey}&amp;buildNumber=${buildNumber}</link>
         <condition class="com.saucelabs.bamboo.sod.plan.ViewSODCondition">
-
         </condition>
     </web-item>
 
@@ -104,7 +103,6 @@
         <label key="Sauce Jobs"/>
         <link linkId="saucePlanDetails">/build/result/viewSauceOnDemandResult.action?buildKey=${buildKey}&amp;buildNumber=${buildNumber}</link>
         <condition class="com.saucelabs.bamboo.sod.plan.ViewSODCondition">
-
         </condition>
     </web-item>
 


### PR DESCRIPTION
@moizjv please review

It used to always show. I updated the conditional check to see if the plugin was enabled for the build definition.

* If it can't find the build/plan, fall back to default behavior (show)
* if it can't find the configuration, fall back to default behavior (show)
* else show if plugin is enabled.