### PR TITLE
generate random port

### DIFF
--- a/src/main/java/com/saucelabs/bamboo/sod/config/SODMappedBuildConfiguration.java
+++ b/src/main/java/com/saucelabs/bamboo/sod/config/SODMappedBuildConfiguration.java
@@ -135,22 +135,6 @@ public class SODMappedBuildConfiguration {
             } else {
                 port = "4444";
             }
-        } else if (port == "0") {
-            try {
-                // get a random port. Prior we used 0 however the ServerSocket was not actually random and
-                // returns the same port when mutliple builds are triggered simultaneously
-                Integer randomPort = (int) Math.floor(Math.random() * ((65000 - 1025) + 1) + 1025);
-                ServerSocket s = new ServerSocket(randomPort);
-
-                Integer.toString(s.getLocalPort());
-                System.out.println("Port was 0, listening on port: " + port);
-            } catch (java.io.IOException e) {
-                if (isSshEnabled()) {
-                    port = "4445";
-                } else {
-                    port = "4444";
-                }
-            }
         }
 
         map.put(SELENIUM_PORT_ENV,port);

--- a/src/main/java/com/saucelabs/bamboo/sod/config/SODMappedBuildConfiguration.java
+++ b/src/main/java/com/saucelabs/bamboo/sod/config/SODMappedBuildConfiguration.java
@@ -137,9 +137,13 @@ public class SODMappedBuildConfiguration {
             }
         } else if (port == "0") {
             try {
-                ServerSocket s = new ServerSocket(0);
-                System.out.println("Port was 0, listening on port: " + s.getLocalPort());
-                port = Integer.toString(s.getLocalPort());
+                // get a random port. Prior we used 0 however the ServerSocket was not actually random and
+                // returns the same port when mutliple builds are triggered simultaneously
+                Integer randomPort = (int) Math.floor(Math.random() * ((65000 - 1025) + 1) + 1025);
+                ServerSocket s = new ServerSocket(randomPort);
+
+                Integer.toString(s.getLocalPort());
+                System.out.println("Port was 0, listening on port: " + port);
             } catch (java.io.IOException e) {
                 if (isSshEnabled()) {
                     port = "4445";
@@ -202,6 +206,4 @@ public class SODMappedBuildConfiguration {
     public String getSauceConnectOptions() {
         return map.get(SAUCE_CONNECT_OPTIONS);
     }
-
-
 }


### PR DESCRIPTION
if users run multiple builds in parallel after setting the the selenium host as 0 (to generate a random port) the plugin often generates the same port for each build causing sauce connect to crash. 
- this issue was easy to replicate and happened frequently

Solution:
remove the breaking code.  if the selenium host is 0, sauce connect will look for an open port to run on. The code removed was forcing sauce connect to use a specific port that may not be available at the time sauce connect is launched, especially if multiple tunnels are started simultaneously. 